### PR TITLE
Add metric carbonation calculator with linked time/pressure sliders

### DIFF
--- a/website/src/components/AppContent.js
+++ b/website/src/components/AppContent.js
@@ -25,9 +25,11 @@ import {
   IconCopy,
   IconBrandGithub,
   IconLeaf,
+  IconChartBubble,
 } from '@tabler/icons-react';
 import HopSelector from './hop-selector/HopSelector';
 import LazySpiderChart, { preloadSpiderChart } from './LazySpiderChart';
+import LazyCarbonationCalculator, { preloadCarbonationCalculator } from './LazyCarbonationCalculator';
 import SelectedHops from './SelectedHops';
 import { useSEO } from '../hooks/useSEO';
 import { updateURL, loadFromURL } from '../utils';
@@ -38,6 +40,7 @@ function AppContent() {
   const [hopData, setHopData] = useState([]);
   const [loading, setLoading] = useState(true);
   const [error, setError] = useState(null);
+  const [currentView, setCurrentView] = useState('main'); // 'main' | 'calculator'
   const { colorScheme, toggleColorScheme } = useMantineColorScheme();
   const isDark = colorScheme === 'dark';
 
@@ -206,7 +209,28 @@ function AppContent() {
           </Group>
 
           <Group gap="xs">
-            {selectedHops.length > 0 && (
+            <Tooltip
+              label={currentView === 'main' ? 'Carbonation Calculator' : 'Back to HopBase'}
+              position="bottom"
+            >
+              <ActionIcon
+                variant="subtle"
+                size="lg"
+                radius="md"
+                onMouseEnter={currentView === 'main' ? preloadCarbonationCalculator : undefined}
+                onClick={() =>
+                  setCurrentView((prev) => (prev === 'main' ? 'calculator' : 'main'))
+                }
+                style={{ color: 'rgba(255,255,255,0.85)' }}
+              >
+                {currentView === 'main' ? (
+                  <IconChartBubble size={18} />
+                ) : (
+                  <IconLeaf size={18} />
+                )}
+              </ActionIcon>
+            </Tooltip>
+            {selectedHops.length > 0 && currentView === 'main' && (
               <Tooltip label="Share comparison" position="bottom">
                 <ActionIcon
                   variant="subtle"
@@ -235,6 +259,9 @@ function AppContent() {
       </AppShell.Header>
 
       <AppShell.Main style={{ background: isDark ? 'var(--mantine-color-dark-8)' : '#f7f9f7' }}>
+        {currentView === 'calculator' ? (
+          <LazyCarbonationCalculator />
+        ) : (
         <Container size="lg" py="md">
           {error && (
             <Alert color="red" mb="md" radius="lg">
@@ -295,6 +322,7 @@ function AppContent() {
             </Stack>
           </Box>
         </Container>
+        )}
       </AppShell.Main>
     </AppShell>
   );

--- a/website/src/components/LazyCarbonationCalculator.js
+++ b/website/src/components/LazyCarbonationCalculator.js
@@ -1,0 +1,33 @@
+import { lazy, Suspense } from 'react';
+import { Paper, Loader, Center, Box, Text } from '@mantine/core';
+
+// Lazy load the CarbonationCalculator component with preload capability
+const CarbonationCalculator = lazy(() =>
+  import(/* webpackChunkName: "carbonation-calculator" */ './carbonation-calculator/CarbonationCalculator')
+);
+
+// Preload function to prefetch the component
+export const preloadCarbonationCalculator = () => {
+  import(/* webpackChunkName: "carbonation-calculator" */ './carbonation-calculator/CarbonationCalculator');
+};
+
+const LazyCarbonationCalculator = () => {
+  return (
+    <Suspense
+      fallback={
+        <Paper shadow="sm" p="lg" m="md">
+          <Center style={{ height: 200 }}>
+            <Box ta="center">
+              <Loader size="md" />
+              <Text size="sm" c="dimmed" mt="sm">Loading Calculator...</Text>
+            </Box>
+          </Center>
+        </Paper>
+      }
+    >
+      <CarbonationCalculator />
+    </Suspense>
+  );
+};
+
+export default LazyCarbonationCalculator;

--- a/website/src/components/carbonation-calculator/CarbonationCalculator.js
+++ b/website/src/components/carbonation-calculator/CarbonationCalculator.js
@@ -1,0 +1,429 @@
+import { useState, useMemo, useCallback, useEffect, useRef } from 'react';
+import {
+  Container,
+  Paper,
+  Stack,
+  Group,
+  Title,
+  Text,
+  Box,
+  SegmentedControl,
+  NumberInput,
+  Slider,
+  Alert,
+  Badge,
+  SimpleGrid,
+  ThemeIcon,
+  Divider,
+  useMantineColorScheme,
+  UnstyledButton,
+} from '@mantine/core';
+import {
+  IconChartBubble,
+  IconTemperature,
+  IconMountain,
+  IconClock,
+  IconGauge,
+  IconBottle,
+  IconAlertTriangle,
+  IconBolt,
+} from '@tabler/icons-react';
+import {
+  VESSEL_PRESETS,
+  CO2_STYLE_PRESETS,
+  V_INITIAL,
+  K_STATIC,
+  K_SHAKE,
+  atmosphericPressure,
+  surfaceArea,
+  absorptionRatio,
+  equilibriumVolumes,
+  equilibriumPressure,
+  timeForTarget,
+  pressureForTarget,
+  shakingTime,
+} from './carbonationUtils';
+
+const MIN_TIME = 0.5;      // hours
+const MAX_TIME = 168;      // 1 week
+const TIME_STEP = 0.5;
+
+const MIN_PRESSURE = 0;    // bar gauge
+const MAX_PRESSURE = 4;
+const PRESSURE_STEP = 0.05;
+
+const clamp = (v, lo, hi) => Math.max(lo, Math.min(hi, v));
+const round2 = (v) => Math.round(v * 100) / 100;
+const round1 = (v) => Math.round(v * 10) / 10;
+
+function formatTime(hours) {
+  if (!Number.isFinite(hours)) return '—';
+  if (hours < 1) return `${Math.round(hours * 60)} min`;
+  if (hours < 24) return `${round1(hours)} h`;
+  const days = hours / 24;
+  return `${round1(days)} days`;
+}
+
+function CarbonationCalculator() {
+  const { colorScheme } = useMantineColorScheme();
+  const isDark = colorScheme === 'dark';
+
+  // Core inputs
+  const [vesselId, setVesselId] = useState(VESSEL_PRESETS[0].id);
+  const [targetVolumes, setTargetVolumes] = useState(2.5);
+  const [temperature, setTemperature] = useState(4);
+  const [altitude, setAltitude] = useState(0);
+
+  // Linked slider state
+  const [time, setTime] = useState(48);          // hours
+  const [pressure, setPressure] = useState(1.0); // bar gauge
+
+  // Which slider the user last drove manually
+  const lastChangedRef = useRef('time');
+  // Prevents ping-pong when we programmatically update the "other" slider
+  const internalUpdateRef = useRef(false);
+
+  const vessel = useMemo(
+    () => VESSEL_PRESETS.find((v) => v.id === vesselId) || VESSEL_PRESETS[0],
+    [vesselId]
+  );
+
+  const P_atm = useMemo(() => atmosphericPressure(altitude), [altitude]);
+  const SA = useMemo(() => surfaceArea(vessel.diameter), [vessel]);
+  const R = useMemo(() => absorptionRatio(SA, vessel.volume), [SA, vessel.volume]);
+
+  // Equilibrium pressure at target volumes and temperature
+  const P_equilibrium = useMemo(
+    () => equilibriumPressure(targetVolumes, temperature, P_atm),
+    [targetVolumes, temperature, P_atm]
+  );
+
+  // Current V_eq at the applied pressure
+  const V_eq_current = useMemo(
+    () => equilibriumVolumes(pressure + P_atm, temperature),
+    [pressure, P_atm, temperature]
+  );
+
+  // Shaking method result
+  const shakeMinutes = useMemo(
+    () => shakingTime(targetVolumes, V_eq_current, V_INITIAL, K_SHAKE),
+    [targetVolumes, V_eq_current]
+  );
+
+  // Warnings
+  const isUnreachable = !Number.isFinite(
+    timeForTarget(targetVolumes, V_eq_current, V_INITIAL, K_STATIC, R)
+  ) && pressure <= P_equilibrium;
+  const pressureTooLow = pressure < P_equilibrium;
+
+  // Handlers for linked sliders
+  const handleTimeChange = useCallback(
+    (newTime) => {
+      lastChangedRef.current = 'time';
+      setTime(newTime);
+      const newPressure = pressureForTarget(
+        targetVolumes,
+        V_INITIAL,
+        K_STATIC,
+        R,
+        newTime,
+        temperature,
+        P_atm
+      );
+      internalUpdateRef.current = true;
+      setPressure(clamp(round2(newPressure), MIN_PRESSURE, MAX_PRESSURE));
+    },
+    [targetVolumes, R, temperature, P_atm]
+  );
+
+  const handlePressureChange = useCallback(
+    (newPressure) => {
+      lastChangedRef.current = 'pressure';
+      setPressure(newPressure);
+      const V_eq = equilibriumVolumes(newPressure + P_atm, temperature);
+      const newTime = timeForTarget(targetVolumes, V_eq, V_INITIAL, K_STATIC, R);
+      internalUpdateRef.current = true;
+      if (Number.isFinite(newTime)) {
+        setTime(clamp(round1(newTime), MIN_TIME, MAX_TIME));
+      } else {
+        setTime(MAX_TIME);
+      }
+    },
+    [targetVolumes, temperature, P_atm, R]
+  );
+
+  // Recalculate the non-driving slider when inputs change
+  useEffect(() => {
+    if (internalUpdateRef.current) {
+      internalUpdateRef.current = false;
+      return;
+    }
+    if (lastChangedRef.current === 'time') {
+      const newPressure = pressureForTarget(
+        targetVolumes,
+        V_INITIAL,
+        K_STATIC,
+        R,
+        time,
+        temperature,
+        P_atm
+      );
+      setPressure(clamp(round2(newPressure), MIN_PRESSURE, MAX_PRESSURE));
+    } else {
+      const V_eq = equilibriumVolumes(pressure + P_atm, temperature);
+      const newTime = timeForTarget(targetVolumes, V_eq, V_INITIAL, K_STATIC, R);
+      if (Number.isFinite(newTime)) {
+        setTime(clamp(round1(newTime), MIN_TIME, MAX_TIME));
+      }
+    }
+    // Only react to input changes — not slider changes (those are handled above)
+    // eslint-disable-next-line react-hooks/exhaustive-deps
+  }, [targetVolumes, temperature, altitude, vesselId]);
+
+  const cardBg = isDark ? 'var(--mantine-color-dark-6)' : 'white';
+
+  return (
+    <Container size="md" py="md">
+      <Stack gap="lg">
+        {/* Header */}
+        <Paper shadow="sm" radius="lg" p="lg" style={{ background: cardBg }}>
+          <Group gap="md" align="center">
+            <ThemeIcon size={44} radius="md" variant="light" color="cyan">
+              <IconChartBubble size={26} />
+            </ThemeIcon>
+            <Box>
+              <Title order={2} style={{ fontFamily: 'Space Grotesk, Inter, sans-serif' }}>
+                Carbonation Calculator
+              </Title>
+              <Text size="sm" c="dimmed">
+                Force-carbonation planner using the Vail/Glass equation (metric units)
+              </Text>
+            </Box>
+          </Group>
+        </Paper>
+
+        {/* Vessel preset selector */}
+        <Paper shadow="sm" radius="lg" p="lg" style={{ background: cardBg }}>
+          <Group gap="xs" mb="sm" align="center">
+            <IconBottle size={16} style={{ color: 'var(--mantine-color-cyan-6)' }} />
+            <Text size="sm" fw={600}>Vessel</Text>
+          </Group>
+          <SegmentedControl
+            fullWidth
+            color="cyan"
+            value={vesselId}
+            onChange={setVesselId}
+            data={VESSEL_PRESETS.map((v) => ({ value: v.id, label: v.label }))}
+          />
+          <Group gap="lg" mt="sm">
+            <Text size="xs" c="dimmed">
+              Volume: <b>{vessel.volume} L</b>
+            </Text>
+            <Text size="xs" c="dimmed">
+              Internal diameter: <b>{vessel.diameter} cm</b>
+            </Text>
+            <Text size="xs" c="dimmed">
+              Surface area: <b>{Math.round(SA)} cm²</b>
+            </Text>
+          </Group>
+        </Paper>
+
+        {/* Inputs */}
+        <Paper shadow="sm" radius="lg" p="lg" style={{ background: cardBg }}>
+          <Text size="sm" fw={600} mb="md">Target & Environment</Text>
+          <SimpleGrid cols={{ base: 1, sm: 3 }} spacing="md">
+            <NumberInput
+              label="Target CO₂ (volumes)"
+              value={targetVolumes}
+              onChange={(v) => setTargetVolumes(Number(v) || 0)}
+              min={1.0}
+              max={5.0}
+              step={0.1}
+              decimalScale={2}
+              leftSection={<IconChartBubble size={16} />}
+            />
+            <NumberInput
+              label="Temperature (°C)"
+              value={temperature}
+              onChange={(v) => setTemperature(Number(v) || 0)}
+              min={-2}
+              max={30}
+              step={0.5}
+              decimalScale={1}
+              leftSection={<IconTemperature size={16} />}
+            />
+            <NumberInput
+              label="Altitude (m)"
+              value={altitude}
+              onChange={(v) => setAltitude(Number(v) || 0)}
+              min={0}
+              max={5000}
+              step={50}
+              leftSection={<IconMountain size={16} />}
+            />
+          </SimpleGrid>
+
+          <Text size="xs" fw={600} c="dimmed" mt="md" mb="xs">
+            Beer style quick presets
+          </Text>
+          <Group gap="xs" wrap="wrap">
+            {CO2_STYLE_PRESETS.map((p) => {
+              const active = Math.abs(targetVolumes - p.vol) < 0.05;
+              return (
+                <UnstyledButton
+                  key={p.label}
+                  onClick={() => setTargetVolumes(p.vol)}
+                  style={{
+                    padding: '4px 10px',
+                    borderRadius: 8,
+                    background: active
+                      ? (isDark ? 'rgba(21,170,191,0.25)' : 'rgba(21,170,191,0.12)')
+                      : (isDark ? 'var(--mantine-color-dark-5)' : 'var(--mantine-color-gray-1)'),
+                    border: `1.5px solid ${
+                      active
+                        ? 'var(--mantine-color-cyan-5)'
+                        : (isDark ? 'var(--mantine-color-dark-3)' : 'var(--mantine-color-gray-3)')
+                    }`,
+                    fontSize: 12,
+                    fontWeight: active ? 600 : 400,
+                    color: active ? 'var(--mantine-color-cyan-7)' : 'inherit',
+                    cursor: 'pointer',
+                    transition: 'all 0.15s ease',
+                  }}
+                >
+                  {p.label} · {p.vol}
+                </UnstyledButton>
+              );
+            })}
+          </Group>
+        </Paper>
+
+        {/* Linked sliders */}
+        <Paper shadow="sm" radius="lg" p="lg" style={{ background: cardBg }}>
+          <Group justify="space-between" mb="xs">
+            <Text size="sm" fw={600}>Static Force Carbonation</Text>
+            <Badge variant="light" color="cyan" size="sm">
+              Equilibrium: {round2(P_equilibrium)} bar
+            </Badge>
+          </Group>
+          <Text size="xs" c="dimmed" mb="lg">
+            Adjust either slider — the other recalculates to hit your target CO₂ at the current
+            temperature and vessel geometry.
+          </Text>
+
+          {/* Time slider */}
+          <Box mb="xl">
+            <Group gap="xs" mb={6} align="center">
+              <IconClock size={14} style={{ color: 'var(--mantine-color-blue-6)' }} />
+              <Text size="xs" fw={600}>Time: {formatTime(time)}</Text>
+            </Group>
+            <Slider
+              color="blue"
+              min={MIN_TIME}
+              max={MAX_TIME}
+              step={TIME_STEP}
+              value={time}
+              onChange={handleTimeChange}
+              label={(v) => formatTime(v)}
+              marks={[
+                { value: 12, label: '12h' },
+                { value: 24, label: '1d' },
+                { value: 72, label: '3d' },
+                { value: 168, label: '7d' },
+              ]}
+              mb="lg"
+            />
+          </Box>
+
+          {/* Pressure slider */}
+          <Box mb="md">
+            <Group gap="xs" mb={6} align="center">
+              <IconGauge size={14} style={{ color: 'var(--mantine-color-orange-6)' }} />
+              <Text size="xs" fw={600}>Pressure: {round2(pressure)} bar gauge</Text>
+            </Group>
+            <Slider
+              color="orange"
+              min={MIN_PRESSURE}
+              max={MAX_PRESSURE}
+              step={PRESSURE_STEP}
+              value={pressure}
+              onChange={handlePressureChange}
+              label={(v) => `${round2(v)} bar`}
+              marks={[
+                { value: 1, label: '1' },
+                { value: 2, label: '2' },
+                { value: 3, label: '3' },
+                { value: 4, label: '4' },
+              ]}
+              mb="lg"
+            />
+          </Box>
+
+          {isUnreachable && (
+            <Alert color="orange" icon={<IconAlertTriangle size={16} />} mt="md" radius="md">
+              Target CO₂ of {targetVolumes} vol is unreachable at {round2(pressure)} bar and{' '}
+              {temperature} °C. Increase pressure above {round2(P_equilibrium)} bar.
+            </Alert>
+          )}
+          {!isUnreachable && pressureTooLow && (
+            <Alert color="yellow" icon={<IconAlertTriangle size={16} />} mt="md" radius="md">
+              Applied pressure is below equilibrium. Target will never be reached — raise pressure.
+            </Alert>
+          )}
+        </Paper>
+
+        {/* Shaking method */}
+        <Paper shadow="sm" radius="lg" p="lg" style={{ background: cardBg }}>
+          <Group gap="xs" mb="xs" align="center">
+            <IconBolt size={16} style={{ color: 'var(--mantine-color-grape-6)' }} />
+            <Text size="sm" fw={600}>Shaking / Rolling Method</Text>
+          </Group>
+          <Text size="xs" c="dimmed" mb="md">
+            Rapid agitation massively accelerates CO₂ absorption. Apply the pressure above,
+            then shake/rock the keg for:
+          </Text>
+          <Group gap="lg" align="baseline">
+            <Title order={3} c={Number.isFinite(shakeMinutes) ? 'grape' : 'dimmed'}>
+              {Number.isFinite(shakeMinutes) ? `~${Math.max(1, Math.ceil(shakeMinutes))} min` : '—'}
+            </Title>
+            <Text size="xs" c="dimmed">
+              at {round2(pressure)} bar, {temperature} °C
+            </Text>
+          </Group>
+        </Paper>
+
+        {/* Summary */}
+        <Paper shadow="sm" radius="lg" p="lg" style={{ background: cardBg }}>
+          <Text size="sm" fw={600} mb="md">Summary</Text>
+          <SimpleGrid cols={{ base: 2, sm: 4 }} spacing="md">
+            <SummaryStat label="Target" value={`${targetVolumes} vol CO₂`} />
+            <SummaryStat label="Static" value={`${round2(pressure)} bar / ${formatTime(time)}`} />
+            <SummaryStat label="Shaking" value={Number.isFinite(shakeMinutes) ? `~${Math.max(1, Math.ceil(shakeMinutes))} min` : '—'} />
+            <SummaryStat label="Atm. pressure" value={`${round2(P_atm)} bar`} />
+          </SimpleGrid>
+          <Divider my="md" />
+          <Text size="xs" c="dimmed">
+            Based on the Vail/Glass equation. Absorption constants are empirical defaults
+            (k = {K_STATIC}, k_shake = {K_SHAKE}). Actual times depend on keg geometry,
+            temperature stability, and CO₂ purity.
+          </Text>
+        </Paper>
+      </Stack>
+    </Container>
+  );
+}
+
+function SummaryStat({ label, value }) {
+  return (
+    <Box>
+      <Text size="xs" c="dimmed" tt="uppercase" fw={600}>
+        {label}
+      </Text>
+      <Text size="md" fw={700}>
+        {value}
+      </Text>
+    </Box>
+  );
+}
+
+export default CarbonationCalculator;

--- a/website/src/components/carbonation-calculator/carbonationUtils.js
+++ b/website/src/components/carbonation-calculator/carbonationUtils.js
@@ -1,0 +1,143 @@
+// Vessel presets with internal dimensions
+export const VESSEL_PRESETS = [
+  { id: 'corny',   label: 'Corny Keg (19L)',  volume: 19, diameter: 21.6 },
+  { id: 'sanke25', label: 'Sanke Keg (25L)',  volume: 25, diameter: 36.3 },
+  { id: 'sanke50', label: 'Sanke Keg (50L)',  volume: 50, diameter: 36.3 },
+];
+
+// Common beer style CO2 volumes for quick presets
+export const CO2_STYLE_PRESETS = [
+  { label: 'British Ale',    vol: 1.5 },
+  { label: 'Porter/Stout',   vol: 1.8 },
+  { label: 'American Ale',   vol: 2.2 },
+  { label: 'Lager',          vol: 2.5 },
+  { label: 'Wheat Beer',     vol: 3.0 },
+  { label: 'Belgian',        vol: 3.5 },
+  { label: 'High Carb',      vol: 4.0 },
+];
+
+// Default constants
+export const V_INITIAL = 0.85;   // CO2 volumes remaining after fermentation
+export const K_STATIC = 0.004;   // Absorption constant for static carbonation (cm^-2 * L * hr^-1)
+export const K_SHAKE = 0.2;      // Absorption constant for shaking method (min^-1)
+
+/**
+ * Atmospheric pressure at a given altitude.
+ * @param {number} H - Altitude in meters
+ * @returns {number} Atmospheric pressure in bar
+ */
+export function atmosphericPressure(H) {
+  return 1.013 * Math.exp(-H / 10197);
+}
+
+/**
+ * Cross-sectional surface area of the liquid in the vessel.
+ * @param {number} d - Internal diameter in cm
+ * @returns {number} Surface area in cm^2
+ */
+export function surfaceArea(d) {
+  return Math.PI * (d / 2) ** 2;
+}
+
+/**
+ * Ratio of gas-liquid contact surface to liquid volume.
+ * @param {number} SA - Surface area in cm^2
+ * @param {number} L - Liquid volume in liters
+ * @returns {number} Absorption ratio (cm^2 / L)
+ */
+export function absorptionRatio(SA, L) {
+  return SA / L;
+}
+
+/**
+ * Equilibrium CO2 volumes at a given absolute pressure and temperature.
+ * Vail/Glass equation: V = P_abs * exp(-(2617.25 / T_K) + 10.7527)
+ * @param {number} P_abs - Absolute pressure in bar
+ * @param {number} T - Temperature in Celsius
+ * @returns {number} CO2 volumes
+ */
+export function equilibriumVolumes(P_abs, T) {
+  const T_K = T + 273.15;
+  return P_abs * Math.exp(-(2617.25 / T_K) + 10.7527);
+}
+
+/**
+ * Gauge pressure required to achieve target CO2 volumes at a given temperature.
+ * Inverse of the Vail/Glass equation.
+ * @param {number} V - Target CO2 volumes
+ * @param {number} T - Temperature in Celsius
+ * @param {number} P_atm - Atmospheric pressure in bar (default 1.013)
+ * @returns {number} Gauge pressure in bar
+ */
+export function equilibriumPressure(V, T, P_atm = 1.013) {
+  const T_K = T + 273.15;
+  const exponent = -(2617.25 / T_K) + 10.7527;
+  const P_abs = V / Math.exp(exponent);
+  return P_abs - P_atm;
+}
+
+/**
+ * CO2 volumes dissolved after time t at a given applied gauge pressure.
+ * Exponential absorption model.
+ * @param {number} V_eq - Equilibrium CO2 volumes at applied pressure
+ * @param {number} V_initial - Initial CO2 volumes in the beer
+ * @param {number} k - Absorption constant
+ * @param {number} R - Absorption ratio (SA / volume)
+ * @param {number} t - Time in hours
+ * @returns {number} CO2 volumes at time t
+ */
+export function volumesAtTime(V_eq, V_initial, k, R, t) {
+  const decay = Math.exp(-k * R * t);
+  return V_eq * (1 - decay) + V_initial * decay;
+}
+
+/**
+ * Time required to reach target CO2 volumes at a given gauge pressure.
+ * @param {number} V_target - Target CO2 volumes
+ * @param {number} V_eq - Equilibrium CO2 volumes at applied pressure
+ * @param {number} V_initial - Initial CO2 volumes
+ * @param {number} k - Absorption constant
+ * @param {number} R - Absorption ratio
+ * @returns {number} Time in hours, or Infinity if unreachable
+ */
+export function timeForTarget(V_target, V_eq, V_initial, k, R) {
+  if (V_eq <= V_initial || V_target >= V_eq) return Infinity;
+  const ratio = (V_target - V_eq) / (V_initial - V_eq);
+  if (ratio <= 0) return Infinity;
+  return -Math.log(ratio) / (k * R);
+}
+
+/**
+ * Required gauge pressure to reach target CO2 volumes in a given time.
+ * Inverts the exponential absorption model to find V_eq, then converts to pressure.
+ * @param {number} V_target - Target CO2 volumes
+ * @param {number} V_initial - Initial CO2 volumes
+ * @param {number} k - Absorption constant
+ * @param {number} R - Absorption ratio
+ * @param {number} t - Time in hours
+ * @param {number} T - Temperature in Celsius
+ * @param {number} P_atm - Atmospheric pressure in bar
+ * @returns {number} Required gauge pressure in bar
+ */
+export function pressureForTarget(V_target, V_initial, k, R, t, T, P_atm = 1.013) {
+  const decay = Math.exp(-k * R * t);
+  if (decay >= 1) return Infinity;
+  const V_eq_needed = (V_target - V_initial * decay) / (1 - decay);
+  if (V_eq_needed <= 0) return 0;
+  return equilibriumPressure(V_eq_needed, T, P_atm);
+}
+
+/**
+ * Time to reach target carbonation using the shaking/rolling method.
+ * @param {number} V_target - Target CO2 volumes
+ * @param {number} V_eq - Equilibrium CO2 volumes at applied pressure
+ * @param {number} V_initial - Initial CO2 volumes
+ * @param {number} k_shake - Shaking absorption constant (min^-1)
+ * @returns {number} Time in minutes, or Infinity if unreachable
+ */
+export function shakingTime(V_target, V_eq, V_initial, k_shake = K_SHAKE) {
+  if (V_eq <= V_initial || V_target >= V_eq) return Infinity;
+  const ratio = (V_target - V_eq) / (V_initial - V_eq);
+  if (ratio <= 0) return Infinity;
+  return -Math.log(ratio) / k_shake;
+}

--- a/website/src/utils/icons.js
+++ b/website/src/utils/icons.js
@@ -15,5 +15,6 @@ export {
   IconCheck,
   IconCopy,
   IconX,
-  IconHelp
+  IconHelp,
+  IconChartBubble
 } from '@tabler/icons-react';


### PR DESCRIPTION
Adds a new carbonation calculator page accessible from the header via a
bubble icon. Uses the Vail/Glass equation with metric units (Celsius,
Bar, cm, L, m) and supports Corny and Sanke 25/50L keg presets.

The two sliders for time and pressure are linked: changing one
recalculates the other to hit the target CO2 volume at the given
temperature, vessel geometry and altitude. Also shows a shaking/rolling
method estimate in minutes.