### PR TITLE
Add CNAME so GitHub Pages serves www.grontved.xyz

### DIFF
--- a/website/public/CNAME
+++ b/website/public/CNAME
@@ -1,0 +1,1 @@
+www.grontved.xyz


### PR DESCRIPTION
Pages is configured with a custom domain (www.grontved.xyz), but the
deploy workflow uses actions/upload-pages-artifact, which replaces the
served site contents on every deploy. Without a CNAME file in the
artifact, the custom domain gets de-verified by Pages and the site
stops serving.

CRA copies public/ to build/ verbatim, so this lands in the artifact.