### PR TITLE
Remove stray CNAME that broke project Pages serving

### DIFF
--- a/website/public/CNAME
+++ b/website/public/CNAME
@@ -1,1 +1,0 @@
-www.grontved.xyz


### PR DESCRIPTION
HopDatabase is a project page served at www.grontved.xyz/HopDatabase/,
inheriting the custom domain from the kasperg3.github.io user-site that
owns www.grontved.xyz. All asset paths, data fetches, and SEO canonical
URLs in this repo target the /HopDatabase/ subpath accordingly.

A previous fix added a CNAME file (www.grontved.xyz) to this repo, which
makes the HopDatabase project claim the apex domain for itself. Two Pages
sites cannot own the same custom domain, so GitHub de-verifies the
conflicting claim and the project page stops serving.

Removing the CNAME lets the project inherit the apex domain and serve
correctly at www.grontved.xyz/HopDatabase/ again.